### PR TITLE
Continue integration with yoast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-# Schema Options
+# LeadsNearby Schema Options
 
-Plugin to easily add schema to Wordpress site
-
-### Shortcodes
-
-[lnb-schema-areaserved]
-
-Available attributes:
-* **cities**: List of cities to be exploded into array
-* **state**: State corresponding to cities attribute
-* **url**: URL for link to page corresponding to cities attribute
-* **type**: default is textblock
-* **list_cols**: default is four
-
-Example: [lnb-schema-areaserved cities="City1, City2, City3, City4, City5" state="NC" url="http://adomain.com/service-area/{city}-{state}-service/" type="list" list_cols="three"]
+Plugin to extend and customize Yoast SEO schema functionality.

--- a/schema-options.php
+++ b/schema-options.php
@@ -63,6 +63,10 @@ add_filter('wpseo_schema_organization', function ($graph_piece) {
     // Switch type from Organization
     $type = get_option('lnb_schema_itemtype', 'LocalBusiness');
     $graph_piece['@type'] = $type;
+    if (empty($graph_piece['name'])) {
+        $wp_site_name = get_bloginfo('name');
+        $graph_piece['name'] = $wp_site_name;
+    }
     if (class_exists('Avada')) {
         $theme_social_links = Avada()->settings->get('social_media_icons', 'url');
         $theme_logo = Avada()->settings->get('logo');

--- a/schema-options.php
+++ b/schema-options.php
@@ -72,7 +72,7 @@ add_filter('wpseo_schema_organization', function ($graph_piece) {
         $theme_logo = Avada()->settings->get('logo');
     }
     $graph_piece['sameAs'] = array_values(array_unique(array_filter(array_merge($graph_piece['sameAs'], $theme_social_links))));
-    if ($theme_logo) {
+    if ($theme_logo && empty($graph_piece['logo'])) {
         $graph_piece['logo'] = array(
             '@type' => 'ImageObject',
             '@id' => trailingslashit(site_url()) . '#logo',

--- a/schema-options.php
+++ b/schema-options.php
@@ -3,7 +3,7 @@
 Plugin Name: LeadsNearby Schema Options
 Plugin URI: http://leadsnearby.com/
 Description: Creates admin page to enter global schema and adds a meta box to each page add schema page description and select custom schema itemtype for clients with more than one business veritical.
-Version: 2.0.0
+Version: 2.0.1
 Author: LeadsNearby
 Author URI: http://leadsnearby.com/
 License: GPLv2 or later


### PR DESCRIPTION
* Use WP site title as fallback when Yoast Organization name is blank
* If Organization Logo is set in Yoast, use as priority over theme logo
* Update README for new plugin trajectory as extension to Yoast